### PR TITLE
add workflow to build and publish actions as docker images

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,84 @@
+name: release
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - master
+
+jobs:
+
+  release-cert-checker:
+    runs-on: ubuntu-latest
+    name: release-cert-checker
+    steps:
+      - name: checkout repository
+        uses: actions/checkout@v2
+      - name: release cert-checker
+        uses: docker/build-push-action@v1
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+          repository: ubio/cert-checker
+          path: ./cert-checker
+          tag_with_sha: true
+
+  release-cert-notifier:
+    runs-on: ubuntu-latest
+    name: release-cert-notifier
+    steps:
+      - name: checkout repository
+        uses: actions/checkout@v2
+      - name: release cert-notifier
+        uses: docker/build-push-action@v1
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+          repository: ubio/cert-notifier
+          path: ./cert-notifier
+          tag_with_sha: true
+
+  release-pull-request:
+    runs-on: ubuntu-latest
+    name: release-pull-request
+    steps:
+      - name: checkout repository
+        uses: actions/checkout@v2
+      - name: release pull-request
+        uses: docker/build-push-action@v1
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+          repository: ubio/pull-request
+          path: ./pull-request
+          tag_with_sha: true
+
+  release-repository-dispatch:
+    runs-on: ubuntu-latest
+    name: release-repository-dispatch
+    steps:
+      - name: checkout repository
+        uses: actions/checkout@v2
+      - name: release repository-dispatch
+        uses: docker/build-push-action@v1
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+          repository: ubio/repository-dispatch
+          path: ./repository-dispatch
+          tag_with_sha: true
+
+  release-rsslack:
+    runs-on: ubuntu-latest
+    name: release-rsslack
+    steps:
+      - name: checkout repository
+        uses: actions/checkout@v2
+      - name: release rsslack
+        uses: docker/build-push-action@v1
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+          repository: ubio/rsslack
+          path: ./rsslack
+          tag_with_sha: true

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -19,7 +19,7 @@ jobs:
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
-          repository: ubio/cert-checker
+          repository: automationcloud/cert-checker
           path: ./cert-checker
           tag_with_sha: true
 
@@ -34,7 +34,7 @@ jobs:
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
-          repository: ubio/cert-notifier
+          repository: automationcloud/cert-notifier
           path: ./cert-notifier
           tag_with_sha: true
 
@@ -49,7 +49,7 @@ jobs:
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
-          repository: ubio/pull-request
+          repository: automationcloud/pull-request
           path: ./pull-request
           tag_with_sha: true
 
@@ -64,7 +64,7 @@ jobs:
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
-          repository: ubio/repository-dispatch
+          repository: automationcloud/repository-dispatch
           path: ./repository-dispatch
           tag_with_sha: true
 
@@ -79,6 +79,6 @@ jobs:
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
-          repository: ubio/rsslack
+          repository: automationcloud/rsslack
           path: ./rsslack
           tag_with_sha: true


### PR DESCRIPTION
This PR adds a workflow to build each action and publish to Docker Hub under the Ubio org. There's currently as assumption that the image will be pushed to `ubio/{name}`, but I wonder if we should namespace this to `ubio/github-action-{name}` just to be explicit.

The new workflow will tag the images as `sha-{sha}` and `latest` on each build, and it's worth calling out that there isn't a way to build an individual action unless we create a workflow for each of them; I've added a manual `workflow_dispatch` trigger for this workflow too. 

This is currently blocked by:

- [x] Docker Hub Account
- [x] Docker Hub username/password added as secrets to this repo.