### PR TITLE
update workflow to use GitHub Action Docker image(s)

### DIFF
--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -14,7 +14,7 @@ jobs:
       # - name: Make change
       #   run: echo "World" > hello.txt
       # - name: Run
-      #   uses: ubio/github-actions/pull-request@master
+      #   uses: docker://automationcloud/pull-request:latest@master
       #   with:
       #     token: ${{ secrets.ACCESS_TOKEN }}
       #     owner: ${{ secrets.PR_OWNER }}

--- a/.github/workflows/repository-dispatch.yaml
+++ b/.github/workflows/repository-dispatch.yaml
@@ -11,7 +11,7 @@ jobs:
     name: Run the repository dispatch action
     steps:
       - name: Run
-        uses: ubio/github-actions/repository-dispatch@master
+        uses: docker://automationcloud/repository-dispatch:latest
         with:
           token: ${{ secrets.ACCESS_TOKEN }}
           owner: ${{ secrets.REPO_DISPATCH_OWNER }}

--- a/.github/workflows/slack.yaml
+++ b/.github/workflows/slack.yaml
@@ -12,7 +12,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Run
-        uses: ubio/github-actions/rsslack@master
+        uses: docker://automationcloud/rsslack:latest
         with:
           channel: "@aw"
           message: "👋 hey from slack"


### PR DESCRIPTION
This PR updates the GitHub Action workflows to use the pre-built Docker images instead of building them at runtime.