### PR TITLE
Improve/remove docker layer caching

### DIFF
--- a/.github/workflows/ci-build.yaml
+++ b/.github/workflows/ci-build.yaml
@@ -62,7 +62,7 @@ jobs:
           labels: |
             source-url=https://github.com/${{ github.repository }}
           cache-from: type=local,src=/tmp/.buildx-cache
-          cache-to: type=local,dest=/tmp/.buildx-cache-new
+          cache-to: type=local,mode=max,dest=/tmp/.buildx-cache-new
       - name: Update Cache
         run: |
           rm -rf /tmp/.buildx-cache


### PR DESCRIPTION
https://github.com/ubio/github-actions/pull/56 follow up.

Export all the layers of all intermediate steps, not only layers for the resulting image (default)

- https://github.com/moby/buildkit#registry-push-image-and-cache-separately
- https://evilmartians.com/chronicles/build-images-on-github-actions-with-docker-layer-caching

~Also, with `${{ runner.os }}-buildx-${{ github.sha }}` cache key **new commits never hit cache**, thus it will be effective for **re-runs only**.~ (not true b/c of `restore-keys:`)

And even if it works, typical `Dockerfile` looks like this:

```Dockerfile
FROM node:18.13.0-alpine as builder

WORKDIR /builder
COPY ./tsconfig.json ./tsconfig.json
COPY ./package.json ./package.json
COPY ./package-lock.json ./package-lock.json
COPY ./src ./src

RUN npm install && \
...
```

We build when we have a new version of application. New version means updated `package.json` thus, `COPY ./package.json` invalidates all cached layers (if we have any). :-\

On top of this, my experiments shows `npm i` isn't the main contributor to build time, `npm run compile` is, and we don't want to cache compilation results.

Shall we give up this idea and live without docker layers caching for builds, and revert #56?