### PR TITLE
Add platform to ci build

### DIFF
--- a/.github/workflows/ci-build.yaml
+++ b/.github/workflows/ci-build.yaml
@@ -14,6 +14,10 @@ on:
         required: false
         type: string
         default: "Dockerfile"
+      platform:
+        required: false
+        type: string
+        default: ""
     secrets:
       REGISTRY_SECRET:
         required: true
@@ -44,6 +48,7 @@ jobs:
         with:
           tags: ${{ inputs.image }}:${{ env.TAG }},${{ inputs.image }}:latest
           file: ${{ inputs.file }}
+          platform: ${{ inputs.platform }}
           push: true
           build-args: |
             NPM_TOKEN=${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/ci-build.yaml
+++ b/.github/workflows/ci-build.yaml
@@ -17,7 +17,7 @@ on:
       platform:
         required: false
         type: string
-        default: ""
+        default: "linux/x86_64"
     secrets:
       REGISTRY_SECRET:
         required: true


### PR DESCRIPTION
We want to set platform on docker build which can be done with `--platform linux/amd64` for example. 
Since we're using docker-build-and-push plugin here's and update for our workflow.

Plugin docs: https://github.com/marketplace/actions/docker-build-push-action