### PR TITLE
add assignees on automatic PR

### DIFF
--- a/.github/workflows/cd-dispatch-deploy.yaml
+++ b/.github/workflows/cd-dispatch-deploy.yaml
@@ -19,6 +19,10 @@ on:
       auto_merge:
         required: true
         type: boolean
+      pr_reviewers:
+        type: string
+        required: false
+        default: ""
     secrets:
       ACCESS_TOKEN:
         required: true
@@ -48,5 +52,6 @@ jobs:
               "image_tag": "${{ env.RELEASE_VERSION }}",
               "env_name": "${{ inputs.env_name }}",
               "app_path": "${{ inputs.app_path }}",
-              "auto_merge": ${{ inputs.auto_merge }}
+              "auto_merge": ${{ inputs.auto_merge }},
+              "pr_reviewers": ${{ inputs.pr_reviewers }}
             }

--- a/.github/workflows/cd-dispatch-deploy.yaml
+++ b/.github/workflows/cd-dispatch-deploy.yaml
@@ -19,7 +19,7 @@ on:
       auto_merge:
         required: true
         type: boolean
-      pr_reviewers:
+      pr_assignees:
         type: string
         required: false
         default: ""
@@ -53,5 +53,5 @@ jobs:
               "env_name": "${{ inputs.env_name }}",
               "app_path": "${{ inputs.app_path }}",
               "auto_merge": ${{ inputs.auto_merge }},
-              "pr_reviewers": ${{ inputs.pr_reviewers }}
+              "pr_assignees": ${{ inputs.pr_assignees }}
             }

--- a/.github/workflows/cd-pr-generic.yaml
+++ b/.github/workflows/cd-pr-generic.yaml
@@ -25,7 +25,7 @@ on:
       auto_merge:
         type: boolean
         required: true
-      reviewers:
+      assignees:
         type: string
         required: false
         default: ""
@@ -67,4 +67,4 @@ jobs:
           draft: false
           maintainer_can_modify: true
           merge: ${{ inputs.auto_merge }}
-          reviewers: ${{ inputs.reviewers }}
+          assignees: ${{ inputs.assignees }}

--- a/.github/workflows/cd-pr-generic.yaml
+++ b/.github/workflows/cd-pr-generic.yaml
@@ -25,6 +25,10 @@ on:
       auto_merge:
         type: boolean
         required: true
+      reviewers:
+        type: string
+        required: false
+        default: ""
     secrets:
       ACCESS_TOKEN:
         required: true
@@ -63,3 +67,4 @@ jobs:
           draft: false
           maintainer_can_modify: true
           merge: ${{ inputs.auto_merge }}
+          reviewers: ${{ inputs.reviewers }}

--- a/pull-request/README.md
+++ b/pull-request/README.md
@@ -20,11 +20,12 @@ The PR author is set to the owner of the access token.
 | draft                 | `false`   | `false` | Whether the PR is in draft status
 | maintainer_can_modify | `false`   | `true`  | Whether repo maintainers can modify the PR
 | merge                 | `false`   | `false` | Whether to automatically merge the PR (if mergeable)
+| reviewers             | `false`   | `""`    | Request reviewers for the PR
 
 ## Outputs
 
 | Output  | Description
-| ------- | ----------- 
+| ------- | -----------
 | pr      | The URL to the created Pull Request
 | merged  | true/false indicating whether the Pull Request was merged after creation
 

--- a/pull-request/README.md
+++ b/pull-request/README.md
@@ -20,7 +20,7 @@ The PR author is set to the owner of the access token.
 | draft                 | `false`   | `false` | Whether the PR is in draft status
 | maintainer_can_modify | `false`   | `true`  | Whether repo maintainers can modify the PR
 | merge                 | `false`   | `false` | Whether to automatically merge the PR (if mergeable)
-| reviewers             | `false`   | `""`    | Request reviewers for the PR
+| assignees             | `false`   | `""`    | Add assignees to the PR, if more than one separate with ", "
 
 ## Outputs
 

--- a/pull-request/action.yaml
+++ b/pull-request/action.yaml
@@ -42,8 +42,8 @@ inputs:
     description: Whether to auto-merge the PR once it's mergeable
     required: false
     default: false
-  reviewers:
-    description: Request reviewers for the PR
+  assignees:
+    description: Add assignees to the PR
     required: false
     default: ""
 output:
@@ -68,7 +68,7 @@ runs:
     - ${{ inputs.draft }}
     - ${{ inputs.maintainer_can_modify }}
     - ${{ inputs.merge }}
-    - ${{ inputs.reviewers }}
+    - ${{ inputs.assignees }}
 branding:
   icon: target
   color: gray-dark

--- a/pull-request/action.yaml
+++ b/pull-request/action.yaml
@@ -42,6 +42,10 @@ inputs:
     description: Whether to auto-merge the PR once it's mergeable
     required: false
     default: false
+  reviewers:
+    description: Request reviewers for the PR
+    required: false
+    default: ""
 output:
   pr:
     description: A link to the PR
@@ -64,6 +68,7 @@ runs:
     - ${{ inputs.draft }}
     - ${{ inputs.maintainer_can_modify }}
     - ${{ inputs.merge }}
+    - ${{ inputs.reviewers }}
 branding:
   icon: target
   color: gray-dark

--- a/pull-request/src/main.go
+++ b/pull-request/src/main.go
@@ -100,6 +100,11 @@ func main() {
 		fmt.Println("::set-output name=merged::true")
 		log.Println("successfully merged pull request")
 	}
+
+	pr, err = requestReviewers(pr, *github.ReviewersRequest{
+		Reviewers:     []string{}, // TODO extend PR vars
+		TeamReviewers: []string{},
+	})
 }
 
 // createPR builds and creates the PR on github
@@ -285,4 +290,16 @@ func awaitMergeableState(pr *github.PullRequest) error {
 	}
 
 	return fmt.Errorf("timed out waiting for PR to be mergeable")
+}
+
+func requestReviewers(pr *github.PullRequest, reviewers *github.ReviewersRequest) (*github.PullRequest, error) {
+	pr, _, err := pr.RequestReviewers(
+		ctx,
+		cfg.Owner,
+		cfg.Repo,
+		pr.GetNumber(),
+		reviewers,
+	)
+
+	return pr, err
 }

--- a/pull-request/src/main.go
+++ b/pull-request/src/main.go
@@ -42,6 +42,7 @@ type config struct {
 	MaintainerCanModify bool   `env:"INPUT_MAINTAINER_CAN_MODIFY" envDefault:"true"`
 	Draft               bool   `env:"INPUT_DRAFT" envDefault:"false"`
 	Merge               bool   `env:"INPUT_MERGE" envDefault:"false"`
+	Reviewers           string `env:"INPUT_REVIEWERS" envDefault:""`
 }
 
 func init() {
@@ -101,10 +102,12 @@ func main() {
 		log.Println("successfully merged pull request")
 	}
 
-	pr, err = requestReviewers(pr, *github.ReviewersRequest{
-		Reviewers:     []string{}, // TODO extend PR vars
-		TeamReviewers: []string{},
-	})
+	if cfg.Reviewers != "" {
+		pr, err = requestReviewers(pr, *github.ReviewersRequest{
+			Reviewers:     []string{cfg.Reviewers},
+			TeamReviewers: []string{},
+		})
+	}
 }
 
 // createPR builds and creates the PR on github

--- a/pull-request/src/main.go
+++ b/pull-request/src/main.go
@@ -296,7 +296,7 @@ func awaitMergeableState(pr *github.PullRequest) error {
 }
 
 func requestReviewers(pr *github.PullRequest, reviewers *github.ReviewersRequest) (*github.PullRequest, error) {
-	pr, _, err := pr.RequestReviewers(
+	pr, _, err := client.PullRequests.RequestReviewers(
 		ctx,
 		cfg.Owner,
 		cfg.Repo,


### PR DESCRIPTION
To have the full loop and set the Github user who triggered deployment as reviewer on PR, workflow cd-dispatch-deploy should be called with:
`pr_assignees: ${{ github.actor }}`

and [cd-deploy workflow](https://github.com/ubio/infrastructure/blob/main/.github/workflows/cd-deploy.yaml) in infrastructure repository should forward the pr_assignees from payload to cd-pr-generic workflow by adding this line under with:

`assignees: ${{ github.event.client_payload.pr_assignees }}`